### PR TITLE
change Fixnum to Integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.0.7
-  - Changed Fixnum to Integer [#10](https://github.com/logstash-plugins/logstash-filter-sleep/pull/10)
+  - Changed Fixnum to Integer. Fixnum was deprecated in ruby 2.4. [#10](https://github.com/logstash-plugins/logstash-filter-sleep/pull/10)
 
 ## 3.0.6
   - Update gemspec summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.7
+  - Changed Fixnum to Integer [#10](https://github.com/logstash-plugins/logstash-filter-sleep/pull/10)
+
 ## 3.0.6
   - Update gemspec summary
 

--- a/lib/logstash/filters/sleep.rb
+++ b/lib/logstash/filters/sleep.rb
@@ -82,7 +82,7 @@ class LogStash::Filters::Sleep < LogStash::Filters::Base
     @count += 1
 
     case @time
-      when Fixnum, Float; time = @time
+      when Integer, Float; time = @time
       when nil; # nothing
       else; time = event.sprintf(@time).to_f
     end

--- a/logstash-filter-sleep.gemspec
+++ b/logstash-filter-sleep.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-sleep'
-  s.version         = '3.0.6'
+  s.version         = '3.0.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sleeps for a specified time span"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Since ruby 2.4, Fixnum class warning messages show up in the log. 
Fixnum was deprecated in favor of Integer.

issue
https://github.com/logstash-plugins/logstash-filter-sleep/issues/9
